### PR TITLE
fix: Correct stopping a run process behavior

### DIFF
--- a/backend/df_designer/app/cli.py
+++ b/backend/df_designer/app/cli.py
@@ -89,6 +89,7 @@ def run_app(
 
     # Patch nest_asyncio before import DFF
     import nest_asyncio
+
     nest_asyncio.apply = lambda: None
 
     settings.host = ip_address

--- a/backend/df_designer/app/services/process.py
+++ b/backend/df_designer/app/services/process.py
@@ -139,7 +139,7 @@ class Process(ABC):
             self.process.terminate()
             try:
                 await asyncio.wait_for(self.process.wait(), timeout=10.0)
-                self.logger.debug("Process '%s' was peacefully terminated.", self.id)
+                self.logger.debug("Process '%s' was gracefully terminated.", self.id)
             except asyncio.TimeoutError:
                 self.process.kill()
                 await self.process.wait()


### PR DESCRIPTION
* Avoid hangin indefinitely for terminating the process, by returning the default `uvloop` loop back to the uvicorn server